### PR TITLE
Add unicode support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "color-my-text",
-  "version": "0.1.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "color-my-text",
-      "version": "0.1.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
+        "16": "^0.0.2",
         "glob": "^8.0.3",
         "minimatch": "^5.1.0"
       },
@@ -406,6 +407,14 @@
       },
       "engines": {
         "node": ">=8.9.3"
+      }
+    },
+    "node_modules/16": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/16/-/16-0.0.2.tgz",
+      "integrity": "sha512-AhG4lpdn+/it+U5Xl1bm5SbaHYTH5NfU/vXZkP7E7CHjtVtITuFVZKa3AZP3gN38RDJHYYtEqWmqzCutlXaR7w==",
+      "dependencies": {
+        "numeric": "^1.2.6"
       }
     },
     "node_modules/acorn": {
@@ -1844,6 +1853,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/numeric": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/numeric/-/numeric-1.2.6.tgz",
+      "integrity": "sha512-avBiDAP8siMa7AfJgYyuxw1oyII4z2sswS23+O+ZfV28KrtNzy0wxUFwi4f3RyM4eeeXNs1CThxR7pb5QQcMiw=="
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2541,6 +2555,14 @@
     }
   },
   "dependencies": {
+    "16": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/16/-/16-0.0.2.tgz",
+      "integrity": "sha512-AhG4lpdn+/it+U5Xl1bm5SbaHYTH5NfU/vXZkP7E7CHjtVtITuFVZKa3AZP3gN38RDJHYYtEqWmqzCutlXaR7w==",
+      "requires": {
+        "numeric": "^1.2.6"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
@@ -3882,6 +3904,11 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
+    },
+    "numeric": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/numeric/-/numeric-1.2.6.tgz",
+      "integrity": "sha512-avBiDAP8siMa7AfJgYyuxw1oyII4z2sswS23+O+ZfV28KrtNzy0wxUFwi4f3RyM4eeeXNs1CThxR7pb5QQcMiw=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "color-my-text",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "publisher": "JatinSanghvi",
   "engines": {
     "vscode": "^1.53.0"
@@ -55,6 +55,10 @@
                     },
                     "matchCase": {
                       "description": "Specifies whether to perform case-sensitive match.",
+                      "type": "boolean"
+                    },
+                    "unicode": {
+                      "description": "Specifies whether to enable the Unicode support for regular expressions.",
                       "type": "boolean"
                     },
                     "color": {
@@ -143,6 +147,7 @@
     "*"
   ],
   "dependencies": {
+    "16": "^0.0.2",
     "glob": "^8.0.3",
     "minimatch": "^5.1.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ export function activate(context: vscode.ExtensionContext): void {
 		italic?: boolean;
 		underline?: boolean;
 		strikeThrough?: boolean;
+		unicode?: boolean;
 	};
 
 	enum Color {
@@ -98,9 +99,16 @@ export function activate(context: vscode.ExtensionContext): void {
 					Array.isArray(rule.patterns) && rule.patterns.forEach(pattern => {
 						if (typeof pattern !== 'string') { return; }
 
+						const flags = (() => {
+							let f = "g";
+							if (rule.matchCase !== true) { f = f + "i"; }
+							if (rule.unicode === true) { f = f + "u"; }
+							return f;
+						})();
+
 						let regExp: RegExp;
 						try {
-							regExp = new RegExp(pattern, rule.matchCase === true ? 'g' : 'gi');
+							regExp = new RegExp(pattern,  flags);
 						} catch (e) {
 							return; // Skip invalid regular expression patterns.
 						}


### PR DESCRIPTION
I was trying to use the standard regex Unicode property notation (specifically `\p{L}+`) to match non-ASCII characters common to my native language, but it seems the required flag `u` is not set here:

https://github.com/JatinSanghvi/color-my-text-vscode/blob/4e73420288244872d8827c5d096556782076ca83/src/extension.ts#L103

Just adding the 'u' flag would not be a good idea, due to differences between unicode and non-unicode regexes. So, I created this patch to allow an user to set a boolean option "unicode" for their rules to enable it.

Here's an usage example:

```
{
    "patterns": [":([\\s\\d\\p{L},'-]+?(\\sja\\s[^,.]+|\\.))"],
    "unicode": true,
    "color": "BrightYellow"
}
```